### PR TITLE
Add ZTE router support

### DIFF
--- a/lib/application/auth/sign_in_form/sign_in_form_bloc.dart
+++ b/lib/application/auth/sign_in_form/sign_in_form_bloc.dart
@@ -6,6 +6,7 @@ import 'package:injectable/injectable.dart';
 import 'package:ltemanager2/domain/auth/auth_failure.dart';
 import 'package:ltemanager2/domain/auth/i_auth_facade.dart';
 import 'package:ltemanager2/domain/auth/value_objects.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 part 'sign_in_form_bloc.freezed.dart';
 part 'sign_in_form_event.dart';
@@ -13,9 +14,15 @@ part 'sign_in_form_state.dart';
 
 @injectable
 class SignInFormBloc extends Bloc<SignInFormEvent, SignInFormState> {
-  final IAuthFacade _authFacade;
+  final IAuthFacade _huaweiAuthFacade;
+  final IAuthFacade _zteAuthFacade;
+  final SharedPreferences _preferences;
 
-  SignInFormBloc(this._authFacade) : super(SignInFormState.initial()) {
+  SignInFormBloc(
+    this._huaweiAuthFacade,
+    @Named('RouterZteAuthFacade') this._zteAuthFacade,
+    this._preferences,
+  ) : super(SignInFormState.initial()) {
     on<UsernameChanged>(
       (event, emit) {
         emit(
@@ -62,7 +69,11 @@ class SignInFormBloc extends Bloc<SignInFormEvent, SignInFormState> {
             ),
           );
 
-          failureOrSuccess = await _authFacade.signInWithEmailAndPassword(
+          final manufacturer =
+              _preferences.getString('_manufacturer') ?? 'huawei';
+          final facade =
+              manufacturer == 'zte' ? _zteAuthFacade : _huaweiAuthFacade;
+          failureOrSuccess = await facade.signInWithEmailAndPassword(
             url: state.ipAddress,
             username: state.username,
             password: state.password,

--- a/lib/domain/auth/manufacturer.dart
+++ b/lib/domain/auth/manufacturer.dart
@@ -1,0 +1,1 @@
+enum Manufacturer { huawei, zte }

--- a/lib/infrastructure/auth/router_huawei_auth_facade.dart
+++ b/lib/infrastructure/auth/router_huawei_auth_facade.dart
@@ -15,6 +15,7 @@ import 'package:ltemanager2/infrastructure/core/router_huawei_api.dart';
 import 'package:chopper/chopper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+@Named("HuaweiRouterAuthFacade")
 @LazySingleton(as: IAuthFacade)
 class RouterHuaweiAuthFacade implements IAuthFacade {
   final HuaweiRouterApi _api;

--- a/lib/infrastructure/auth/router_zte_auth_facade.dart
+++ b/lib/infrastructure/auth/router_zte_auth_facade.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:dartz/dartz.dart';
+import 'package:http/http.dart' as http;
+import 'package:injectable/injectable.dart';
+import 'package:ltemanager2/domain/auth/auth_failure.dart';
+import 'package:ltemanager2/domain/auth/i_auth_facade.dart';
+import 'package:ltemanager2/domain/auth/value_objects.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+@LazySingleton(as: IAuthFacade, instanceName: 'RouterZteAuthFacade')
+class RouterZteAuthFacade implements IAuthFacade {
+  final SharedPreferences _sharedPreferences;
+
+  RouterZteAuthFacade(this._sharedPreferences);
+
+  Future<void> _setRouterURL(String url) async {
+    await _sharedPreferences.setString('_baseUrl', url);
+  }
+
+  @override
+  Future<Either<AuthFailure, Unit>> signInWithEmailAndPassword({
+    required IPAddress url,
+    required Username username,
+    required Password password,
+  }) async {
+    final urlStr = url.value.getOrElse(() => '');
+    await _setRouterURL(urlStr);
+    final passwordStr = password.value.getOrElse(() => '');
+
+    try {
+      final ldResp = await http.get(
+        Uri.parse('$urlStr/goform/goform_get_cmd_process?isTest=false&cmd=LD'),
+        headers: {'referer': urlStr},
+      );
+      if (ldResp.statusCode != 200) {
+        return left(const AuthFailure.serverError());
+      }
+      final ld = (jsonDecode(ldResp.body) as Map<String, dynamic>)['LD'] as String;
+
+      final first = sha256.convert(utf8.encode(passwordStr)).toString().toUpperCase();
+      final second = sha256.convert(utf8.encode('$first$ld')).toString().toUpperCase();
+
+      final loginResp = await http.get(
+        Uri.parse('$urlStr/goform/goform_set_cmd_process?isTest=false&goformId=LOGIN&password=$second'),
+        headers: {'referer': urlStr},
+      );
+
+      if (loginResp.statusCode == 200) {
+        final body = jsonDecode(loginResp.body) as Map<String, dynamic>;
+        if (body['result'] == '0') {
+          await _sharedPreferences.setString(
+            '_sessionCookie',
+            loginResp.headers['set-cookie'] ?? '',
+          );
+          return right(unit);
+        }
+        return left(const AuthFailure.invalidEmailAndPasswordCombination());
+      }
+      return left(const AuthFailure.serverError());
+    } catch (_) {
+      return left(const AuthFailure.serverError());
+    }
+  }
+
+  @override
+  Future<Either<AuthFailure, Unit>> isSignedIn() async {
+    final cookie = _sharedPreferences.getString('_sessionCookie') ?? '';
+    if (cookie.isEmpty) {
+      return left(const AuthFailure.notAuthenticated());
+    }
+    return right(unit);
+  }
+
+  @override
+  Future<Either<AuthFailure, Unit>> signOut() async {
+    await _sharedPreferences.setString('_sessionCookie', '');
+    return right(unit);
+  }
+}

--- a/lib/infrastructure/auth/router_zte_auth_facade.dart
+++ b/lib/infrastructure/auth/router_zte_auth_facade.dart
@@ -9,7 +9,8 @@ import 'package:ltemanager2/domain/auth/i_auth_facade.dart';
 import 'package:ltemanager2/domain/auth/value_objects.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-@LazySingleton(as: IAuthFacade, instanceName: 'RouterZteAuthFacade')
+@Named("ZTERouterAuthFacade")
+@LazySingleton(as: IAuthFacade)
 class RouterZteAuthFacade implements IAuthFacade {
   final SharedPreferences _sharedPreferences;
 
@@ -37,13 +38,17 @@ class RouterZteAuthFacade implements IAuthFacade {
       if (ldResp.statusCode != 200) {
         return left(const AuthFailure.serverError());
       }
-      final ld = (jsonDecode(ldResp.body) as Map<String, dynamic>)['LD'] as String;
+      final ld =
+          (jsonDecode(ldResp.body) as Map<String, dynamic>)['LD'] as String;
 
-      final first = sha256.convert(utf8.encode(passwordStr)).toString().toUpperCase();
-      final second = sha256.convert(utf8.encode('$first$ld')).toString().toUpperCase();
+      final first =
+          sha256.convert(utf8.encode(passwordStr)).toString().toUpperCase();
+      final second =
+          sha256.convert(utf8.encode('$first$ld')).toString().toUpperCase();
 
       final loginResp = await http.get(
-        Uri.parse('$urlStr/goform/goform_set_cmd_process?isTest=false&goformId=LOGIN&password=$second'),
+        Uri.parse(
+            '$urlStr/goform/goform_set_cmd_process?isTest=false&goformId=LOGIN&password=$second'),
         headers: {'referer': urlStr},
       );
 

--- a/lib/injection.config.dart
+++ b/lib/injection.config.dart
@@ -12,6 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart' as _i4;
 import 'application/auth/auth_bloc.dart' as _i10;
 import 'application/auth/sign_in_form/sign_in_form_bloc.dart' as _i9;
 import 'domain/auth/i_auth_facade.dart' as _i5;
+import 'infrastructure/auth/router_zte_auth_facade.dart' as _i12;
 import 'infrastructure/auth/router_auth_facade.dart' as _i7;
 import 'infrastructure/auth/router_huawei_auth_facade.dart' as _i6;
 import 'infrastructure/core/module_injectable.dart' as _i11;
@@ -42,15 +43,26 @@ Future<_i1.GetIt> $initGetIt(
         get<_i4.SharedPreferences>(),
       ));
   gh.lazySingleton<_i5.IAuthFacade>(
+    () => _i12.RouterZteAuthFacade(get<_i4.SharedPreferences>()),
+    instanceName: 'RouterZteAuthFacade',
+  );
+  gh.lazySingleton<_i5.IAuthFacade>(
     () => _i7.RouterAuthFacade(
       get<_i8.RouterApi>(),
       get<_i4.SharedPreferences>(),
     ),
     instanceName: 'RouterGenericAuthFacade',
   );
-  gh.factory<_i9.SignInFormBloc>(
-      () => _i9.SignInFormBloc(get<_i5.IAuthFacade>()));
-  gh.factory<_i10.AuthBloc>(() => _i10.AuthBloc(get<_i5.IAuthFacade>()));
+  gh.factory<_i9.SignInFormBloc>(() => _i9.SignInFormBloc(
+        get<_i5.IAuthFacade>(),
+        get<_i5.IAuthFacade>(instanceName: 'RouterZteAuthFacade'),
+        get<_i4.SharedPreferences>(),
+      ));
+  gh.factory<_i10.AuthBloc>(() => _i10.AuthBloc(
+        get<_i5.IAuthFacade>(),
+        get<_i5.IAuthFacade>(instanceName: 'RouterZteAuthFacade'),
+        get<_i4.SharedPreferences>(),
+      ));
   return get;
 }
 

--- a/lib/injection.config.dart
+++ b/lib/injection.config.dart
@@ -9,14 +9,14 @@ import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:shared_preferences/shared_preferences.dart' as _i4;
 
-import 'application/auth/auth_bloc.dart' as _i10;
-import 'application/auth/sign_in_form/sign_in_form_bloc.dart' as _i9;
-import 'domain/auth/i_auth_facade.dart' as _i5;
-import 'infrastructure/auth/router_zte_auth_facade.dart' as _i12;
-import 'infrastructure/auth/router_auth_facade.dart' as _i7;
-import 'infrastructure/auth/router_huawei_auth_facade.dart' as _i6;
-import 'infrastructure/core/module_injectable.dart' as _i11;
-import 'infrastructure/core/router_api.dart' as _i8;
+import 'application/auth/auth_bloc.dart' as _i7;
+import 'application/auth/sign_in_form/sign_in_form_bloc.dart' as _i5;
+import 'domain/auth/i_auth_facade.dart' as _i6;
+import 'infrastructure/auth/router_auth_facade.dart' as _i9;
+import 'infrastructure/auth/router_huawei_auth_facade.dart' as _i8;
+import 'infrastructure/auth/router_zte_auth_facade.dart' as _i11;
+import 'infrastructure/core/module_injectable.dart' as _i12;
+import 'infrastructure/core/router_api.dart' as _i10;
 import 'infrastructure/core/router_huawei_api.dart'
     as _i3; // ignore_for_file: unnecessary_lambdas
 
@@ -38,32 +38,35 @@ Future<_i1.GetIt> $initGetIt(
     () => flutterModule.prefs,
     preResolve: true,
   );
-  gh.lazySingleton<_i5.IAuthFacade>(() => _i6.RouterHuaweiAuthFacade(
-        get<_i3.HuaweiRouterApi>(),
+  gh.factory<_i5.SignInFormBloc>(() => _i5.SignInFormBloc(
+        get<_i6.IAuthFacade>(),
+        get<_i6.IAuthFacade>(instanceName: 'RouterZteAuthFacade'),
         get<_i4.SharedPreferences>(),
       ));
-  gh.lazySingleton<_i5.IAuthFacade>(
-    () => _i12.RouterZteAuthFacade(get<_i4.SharedPreferences>()),
-    instanceName: 'RouterZteAuthFacade',
+  gh.factory<_i7.AuthBloc>(() => _i7.AuthBloc(
+        get<_i6.IAuthFacade>(),
+        get<_i6.IAuthFacade>(instanceName: 'RouterZteAuthFacade'),
+        get<_i4.SharedPreferences>(),
+      ));
+  gh.lazySingleton<_i6.IAuthFacade>(
+    () => _i8.RouterHuaweiAuthFacade(
+      get<_i3.HuaweiRouterApi>(),
+      get<_i4.SharedPreferences>(),
+    ),
+    instanceName: 'HuaweiRouterAuthFacade',
   );
-  gh.lazySingleton<_i5.IAuthFacade>(
-    () => _i7.RouterAuthFacade(
-      get<_i8.RouterApi>(),
+  gh.lazySingleton<_i6.IAuthFacade>(
+    () => _i9.RouterAuthFacade(
+      get<_i10.RouterApi>(),
       get<_i4.SharedPreferences>(),
     ),
     instanceName: 'RouterGenericAuthFacade',
   );
-  gh.factory<_i9.SignInFormBloc>(() => _i9.SignInFormBloc(
-        get<_i5.IAuthFacade>(),
-        get<_i5.IAuthFacade>(instanceName: 'RouterZteAuthFacade'),
-        get<_i4.SharedPreferences>(),
-      ));
-  gh.factory<_i10.AuthBloc>(() => _i10.AuthBloc(
-        get<_i5.IAuthFacade>(),
-        get<_i5.IAuthFacade>(instanceName: 'RouterZteAuthFacade'),
-        get<_i4.SharedPreferences>(),
-      ));
+  gh.lazySingleton<_i6.IAuthFacade>(
+    () => _i11.RouterZteAuthFacade(get<_i4.SharedPreferences>()),
+    instanceName: 'ZTERouterAuthFacade',
+  );
   return get;
 }
 
-class _$FlutterModule extends _i11.FlutterModule {}
+class _$FlutterModule extends _i12.FlutterModule {}

--- a/lib/presentation/pages/sign_in/widgets/sign_in_form.dart
+++ b/lib/presentation/pages/sign_in/widgets/sign_in_form.dart
@@ -8,9 +8,18 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ltemanager2/application/auth/auth_bloc.dart';
 import 'package:ltemanager2/application/auth/sign_in_form/sign_in_form_bloc.dart';
 import 'package:ltemanager2/presentation/routes/router.gr.dart';
+import 'package:ltemanager2/domain/auth/manufacturer.dart';
+import 'package:ltemanager2/utilities/SharedPreferencesFunctions.dart';
 
-class SignInForm extends StatelessWidget {
+class SignInForm extends StatefulWidget {
   const SignInForm({Key? key}) : super(key: key);
+
+  @override
+  State<SignInForm> createState() => _SignInFormState();
+}
+
+class _SignInFormState extends State<SignInForm> {
+  Manufacturer _manufacturer = Manufacturer.huawei;
 
   @override
   Widget build(BuildContext context) {
@@ -256,16 +265,37 @@ class SignInForm extends StatelessWidget {
                                   ),
                                   (_) => null,
                                 ),
-                            onEditingComplete: () =>
-                                TextInput.finishAutofillContext(),
-                          ),
-                        ),
-                      ),
-                    ],
+                    onEditingComplete: () =>
+                        TextInput.finishAutofillContext(),
                   ),
                 ),
-                const Spacer(),
-                const SizedBox(height: 8),
+              ),
+              const SizedBox(height: 8),
+              DropdownButton<Manufacturer>(
+                value: _manufacturer,
+                onChanged: (val) {
+                  if (val != null) {
+                    setState(() {
+                      _manufacturer = val;
+                    });
+                  }
+                },
+                items: const [
+                  DropdownMenuItem(
+                    value: Manufacturer.huawei,
+                    child: Text('Huawei'),
+                  ),
+                  DropdownMenuItem(
+                    value: Manufacturer.zte,
+                    child: Text('ZTE'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const Spacer(),
+        const SizedBox(height: 8),
                 OutlinedButton(
                   style: ButtonStyle(
                     minimumSize: MaterialStateProperty.all(const Size(250, 50)),
@@ -279,6 +309,7 @@ class SignInForm extends StatelessWidget {
                     ),
                   ),
                   onPressed: () {
+                    saveSharedPref('_manufacturer', _manufacturer.name);
                     context.read<SignInFormBloc>().add(
                           const SignInFormEvent
                               .signInWithEmailAndPasswordPressed(),


### PR DESCRIPTION
## Summary
- add manufacturer enum
- implement RouterZteAuthFacade for ZTE routers
- select router manufacturer during login and store preference
- delegate auth actions based on selected manufacturer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68497215d91c8320be174e9dd7e8be98